### PR TITLE
Make the winning bid object nullable

### DIFF
--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -45,13 +45,13 @@ export type Auction = {
 
 export type AuctionBid = {
   __typename?: 'AuctionBid';
-  amount?: Maybe<Scalars['String']>;
-  blockNumber?: Maybe<Scalars['String']>;
-  firstSlot?: Maybe<Scalars['String']>;
+  amount: Scalars['String'];
+  blockNumber: Scalars['String'];
+  firstSlot: Scalars['String'];
   isCrowdloan: Scalars['Boolean'];
-  lastSlot?: Maybe<Scalars['String']>;
-  projectId?: Maybe<Scalars['String']>;
-  projectName?: Maybe<Scalars['String']>;
+  lastSlot: Scalars['String'];
+  projectId: Scalars['String'];
+  projectName: Scalars['String'];
 };
 
 export type AuctionEndingPeriod = {
@@ -938,13 +938,13 @@ export type AuctionBidResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['AuctionBid'] = ResolversParentTypes['AuctionBid'],
 > = {
-  amount?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  blockNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  firstSlot?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  amount?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  firstSlot?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   isCrowdloan?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  lastSlot?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  projectId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  projectName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lastSlot?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  projectId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  projectName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/subschemas/substrate-chain/src/resolvers/Query/auctions.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/auctions.ts
@@ -81,16 +81,17 @@ const getLatestAuction = (
     },
     raised: formatBalance(api, raised),
     raisedPercent,
-    winningBid: latestWinningBid ? {
-      isCrowdloan: Boolean(latestWinningBid.isCrowdloan),
-      firstSlot: formatNumber(latestWinningBid.firstSlot),
-      lastSlot: formatNumber(latestWinningBid.lastSlot),
-      blockNumber: lastWinners.blockNumber.toString(),
-      projectId: latestWinningBid.paraId.toString(),
-      projectName:
-        endpoints?.find((e) => e.paraId === latestWinningBid.paraId.toNumber())?.text?.toString() || '',
-      amount: formatBalance(api, lastWinners.total),
-    } : null,
+    winningBid: latestWinningBid
+      ? {
+          isCrowdloan: Boolean(latestWinningBid.isCrowdloan),
+          firstSlot: formatNumber(latestWinningBid.firstSlot),
+          lastSlot: formatNumber(latestWinningBid.lastSlot),
+          blockNumber: lastWinners.blockNumber.toString(),
+          projectId: latestWinningBid.paraId.toString(),
+          projectName: endpoints?.find((e) => e.paraId === latestWinningBid.paraId.toNumber())?.text?.toString() || '',
+          amount: formatBalance(api, lastWinners.total),
+        }
+      : null,
   };
 };
 

--- a/subschemas/substrate-chain/src/resolvers/Query/auctions.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/auctions.ts
@@ -81,16 +81,16 @@ const getLatestAuction = (
     },
     raised: formatBalance(api, raised),
     raisedPercent,
-    winningBid: {
-      isCrowdloan: Boolean(latestWinningBid?.isCrowdloan),
-      firstSlot: formatNumber(latestWinningBid?.firstSlot),
-      lastSlot: formatNumber(latestWinningBid?.lastSlot),
-      blockNumber: lastWinners?.blockNumber.toString(),
-      projectId: lastWinners?.winners[0].paraId.toString(),
+    winningBid: latestWinningBid ? {
+      isCrowdloan: Boolean(latestWinningBid.isCrowdloan),
+      firstSlot: formatNumber(latestWinningBid.firstSlot),
+      lastSlot: formatNumber(latestWinningBid.lastSlot),
+      blockNumber: lastWinners.blockNumber.toString(),
+      projectId: latestWinningBid.paraId.toString(),
       projectName:
-        endpoints?.find((e) => e.paraId === lastWinners?.winners[0]?.paraId.toNumber())?.text?.toString() || '',
-      amount: String(formatBalance(api, lastWinners?.total)),
-    },
+        endpoints?.find((e) => e.paraId === latestWinningBid.paraId.toNumber())?.text?.toString() || '',
+      amount: formatBalance(api, lastWinners.total),
+    } : null,
   };
 };
 

--- a/subschemas/substrate-chain/src/typeDefs/auctions.ts
+++ b/subschemas/substrate-chain/src/typeDefs/auctions.ts
@@ -21,13 +21,13 @@ export default /* GraphQL */ `
   }
 
   type AuctionBid {
-    blockNumber: String
-    projectId: String
-    projectName: String
-    amount: String
+    blockNumber: String!
+    projectId: String!
+    projectName: String!
+    amount: String!
     isCrowdloan: Boolean!
-    firstSlot: String
-    lastSlot: String
+    firstSlot: String!
+    lastSlot: String!
   }
 
   type Auction {


### PR DESCRIPTION
Even if the auction is active it is possible that the auction ending period hasn't started yet. Thus there won't be any winning bids.

So in this PR the `winningBid` object is made nullable for cases like this.