### PR TITLE
Issue-174 Add necessary data to propose bounty

### DIFF
--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -124,7 +124,11 @@ export type BountiesSummary = {
   __typename?: 'BountiesSummary';
   activeBounties: Scalars['String'];
   bountyCount: Scalars['String'];
+  bountyDepositBase: Scalars['String'];
+  bountyValueMinimum: Scalars['String'];
+  dataDepositPerByte: Scalars['String'];
   formattedTotalValue: Scalars['String'];
+  maximumReasonLength: Scalars['String'];
   pastBounties: Scalars['String'];
   progressPercent: Scalars['Int'];
   timeLeft: Array<Scalars['String']>;
@@ -1215,7 +1219,11 @@ export type BountiesSummaryResolvers<
 > = {
   activeBounties?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   bountyCount?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  bountyDepositBase?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  bountyValueMinimum?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  dataDepositPerByte?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedTotalValue?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  maximumReasonLength?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   pastBounties?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   progressPercent?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   timeLeft?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;

--- a/subschemas/substrate-chain/src/typeDefs/bounties.ts
+++ b/subschemas/substrate-chain/src/typeDefs/bounties.ts
@@ -7,6 +7,10 @@ export default /* GraphQL */ `
     formattedTotalValue: String!
     timeLeft: [String!]!
     progressPercent: Int!
+    bountyDepositBase: String!
+    bountyValueMinimum: String!
+    dataDepositPerByte: String!
+    maximumReasonLength: String!
   }
 
   type Curator {


### PR DESCRIPTION
Additional data that are mentioned [here](https://github.com/litentry/litentry-graph/issues/174) is added to the bounties summary.

`proposeBounty` is not added. Please refer to [this](https://github.com/litentry/litentry-graph/issues/174#issuecomment-1067787709) comment.