### PR TITLE
148 - refactor crowdloan resolvers

### DIFF
--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -266,6 +266,11 @@ export type CrowdloanContribution = {
   paraId: Scalars['String'];
 };
 
+export enum CrowdloanStatus {
+  Active = 'Active',
+  Ended = 'Ended',
+}
+
 export type CrowdloanSummary = {
   __typename?: 'CrowdloanSummary';
   activeCap: Scalars['String'];
@@ -522,6 +527,7 @@ export type Query = {
   crowdloan?: Maybe<Crowdloan>;
   crowdloanContribution: CrowdloanContribution;
   crowdloanSummary: CrowdloanSummary;
+  crowdloans: Array<Crowdloan>;
   democracyProposal?: Maybe<DemocracyProposal>;
   democracyProposals: Array<DemocracyProposal>;
   democracyReferendum?: Maybe<DemocracyReferendum>;
@@ -568,6 +574,10 @@ export type QueryCrowdloanArgs = {
 
 export type QueryCrowdloanContributionArgs = {
   paraId: Scalars['String'];
+};
+
+export type QueryCrowdloansArgs = {
+  status?: InputMaybe<CrowdloanStatus>;
 };
 
 export type QueryDemocracyProposalArgs = {
@@ -864,6 +874,7 @@ export type ResolversTypes = {
     }
   >;
   CrowdloanContribution: ResolverTypeWrapper<CrowdloanContribution>;
+  CrowdloanStatus: CrowdloanStatus;
   CrowdloanSummary: ResolverTypeWrapper<CrowdloanSummary>;
   Curator: ResolverTypeWrapper<PartialCurator>;
   DemocracyProposal: ResolverTypeWrapper<
@@ -1758,6 +1769,12 @@ export type QueryResolvers<
     RequireFields<QueryCrowdloanContributionArgs, 'paraId'>
   >;
   crowdloanSummary?: Resolver<ResolversTypes['CrowdloanSummary'], ParentType, ContextType>;
+  crowdloans?: Resolver<
+    Array<ResolversTypes['Crowdloan']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryCrowdloansArgs, never>
+  >;
   democracyProposal?: Resolver<
     Maybe<ResolversTypes['DemocracyProposal']>,
     ParentType,

--- a/subschemas/substrate-chain/src/resolvers/Query/crowdloan.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/crowdloan.ts
@@ -106,7 +106,7 @@ export async function endedCrowdloans(
 
 export async function crowdloans(
   _: Record<string, never>,
-  {status: status}: {status: CrowdloanStatus},
+  {status}: {status?: CrowdloanStatus | undefined | null},
   {api}: Context,
 ): Promise<CrowdloanInfo[]> {
   const [paraIdKeys, bestNumber] = await Promise.all([

--- a/subschemas/substrate-chain/src/resolvers/Query/index.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/index.ts
@@ -6,7 +6,7 @@ import chainInfo from './chainInfo';
 import {council} from './council';
 import {councilVote} from './councilVote';
 import {convictions} from './convictions';
-import {crowdloanSummary, activeCrowdloans, endedCrowdloans, crowdloan} from './crowdloan';
+import {crowdloanSummary, activeCrowdloans, endedCrowdloans, crowdloan, crowdloans} from './crowdloan';
 import {councilMotions, councilMotionDetail} from './councilMotions';
 import {crowdloanContribution} from './CrowdloanContribution';
 import {
@@ -42,6 +42,7 @@ export const Query = {
   activeCrowdloans,
   endedCrowdloans,
   crowdloan,
+  crowdloans,
   crowdloanContribution,
   democracySummary,
   democracyProposals,

--- a/subschemas/substrate-chain/src/services/crowdloanService.ts
+++ b/subschemas/substrate-chain/src/services/crowdloanService.ts
@@ -1,4 +1,4 @@
-import type {LeasePeriod} from '../generated/resolvers-types';
+import {CrowdloanStatus, LeasePeriod} from '../generated/resolvers-types';
 import {ApiPromise} from '@polkadot/api';
 import type {Option} from '@polkadot/types';
 import type {ITuple} from '@polkadot/types/types';
@@ -8,7 +8,7 @@ import type {ParaId, BlockNumber, FundInfo, AccountId, BalanceOf} from '@polkado
 
 const CROWD_PREFIX = stringToU8a('modlpy/cfund');
 
-type Campaign = {
+export type Campaign = {
   info: FundInfo;
   isCapped?: boolean;
   isEnded?: boolean;
@@ -150,6 +150,19 @@ export function extractEndedFunds(funds: Campaign[], leasePeriod: LeasePeriod): 
   return funds.filter(
     ({firstSlot, isCapped, isEnded, isWinner}) => isCapped || isEnded || isWinner || currentPeriod.gt(firstSlot),
   );
+}
+
+export function extractFunds(status: CrowdloanStatus, funds: Campaign[], leasePeriod: LeasePeriod): Campaign[] {
+  if (!status) {
+    return funds;
+  }
+
+  switch (status) {
+    case CrowdloanStatus.Active:
+      return extractActiveFunds(funds, leasePeriod);
+    case CrowdloanStatus.Ended:
+      return extractEndedFunds(funds, leasePeriod);
+  }
 }
 
 export function extractParaIds(funds: Campaign[]): ParaId[] {

--- a/subschemas/substrate-chain/src/services/crowdloanService.ts
+++ b/subschemas/substrate-chain/src/services/crowdloanService.ts
@@ -152,7 +152,11 @@ export function extractEndedFunds(funds: Campaign[], leasePeriod: LeasePeriod): 
   );
 }
 
-export function extractFunds(status: CrowdloanStatus, funds: Campaign[], leasePeriod: LeasePeriod): Campaign[] {
+export function extractFunds(
+  status: CrowdloanStatus | undefined | null,
+  funds: Campaign[],
+  leasePeriod: LeasePeriod,
+): Campaign[] {
   if (!status) {
     return funds;
   }

--- a/subschemas/substrate-chain/src/typeDefs/crowdloan.ts
+++ b/subschemas/substrate-chain/src/typeDefs/crowdloan.ts
@@ -1,4 +1,9 @@
 export default /* GraphQL */ `
+  enum CrowdloanStatus {
+    Active
+    Ended
+  }
+
   type CrowdloanSummary {
     activeRaised: String!
     formattedActiveRaised: String!
@@ -45,5 +50,6 @@ export default /* GraphQL */ `
     activeCrowdloans: [Crowdloan!]!
     endedCrowdloans: [Crowdloan!]!
     crowdloan(paraId: String!): Crowdloan
+    crowdloans(status: CrowdloanStatus): [Crowdloan!]!
   }
 `;


### PR DESCRIPTION
Added a new `substrateChainCrowdloans(status)` resolver. 

I've refactored the crowdloan details and they were a bit different from each other. I think I aligned it the best but let me know if you spot some breaking changes, particularly to the previous existing queries.

Here is a query for you to test and compare:
```
query {
	newActive: substrateChainCrowdloans(status: Active) {
		paraId
		name
		status
	}
	oldActive: substrateChainActiveCrowdloans {
		paraId
		name
		status
	}
	newEnded: substrateChainCrowdloans(status: Ended) {
		paraId
		name
		status
	}
	oldEnded: substrateChainEndedCrowdloans {
		paraId
		name
		status
	}
	all: substrateChainCrowdloans {
		paraId
		name
		status
	}
}

```