### PR TITLE
Initial support for Litmus in the substrate-chain subschema

### DIFF
--- a/graphql-server/src/substrateApi.ts
+++ b/graphql-server/src/substrateApi.ts
@@ -1,11 +1,14 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
 
-export type SubstrateNetwork = 'kusama' | 'polkadot';
+export type SubstrateNetwork = 'kusama' | 'polkadot' | 'litmus';
 
 // TODO: get ws providers from .env
 const polkadotWsProvider = new WsProvider('wss://rpc.polkadot.io');
 const kusamaWsProvider = new WsProvider(
-  'wss://kusama.api.onfinality.io/public-ws',
+  'wss://kusama.api.onfinality.io/public-ws'
+);
+const litmusWsProvider = new WsProvider(
+  'wss://rpc.litmus-parachain.litentry.io'
 );
 
 export async function initSubstrateApi() {
@@ -15,9 +18,14 @@ export async function initSubstrateApi() {
   const kusamaApi = await ApiPromise.create({ provider: kusamaWsProvider });
   await kusamaApi.isReady;
 
+  const litmusApi = await ApiPromise.create({ provider: litmusWsProvider });
+  await litmusApi.isReady;
+
   return (network?: SubstrateNetwork) => {
     if (network === 'kusama') {
       return kusamaApi;
+    } else if (network === 'litmus') {
+      return litmusApi;
     }
     return polkadotApi;
   };

--- a/subschemas/substrate-chain/src/resolvers/Query/account.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/account.ts
@@ -20,9 +20,8 @@ export async function account(
   }
 
   const account = await accountsService.getAccount(address);
-
-  const subAccountsData = await api.query.identity.subsOf(address);
-  const subAccounts = subAccountsData[1].map((accountId) => ({address: accountId.toString()}));
+  const subAccountsData = await api.query.identity?.subsOf(address);
+  const subAccounts = subAccountsData?.[1].map((accountId) => ({address: accountId.toString()}));
 
   return {
     ...account,


### PR DESCRIPTION
We are adding support for Litmus in the mobile apps so we need to support it here. This is an "initial" setup because Litmus does not have all the pallets that the relay chains have so some queries won't work.. Here I'm just fixing the accounts resolver because it's the only one we need for now.