### PR TITLE
Stitch Polkassembly schema into Litentry graph

### DIFF
--- a/graphql-server/src/config.ts
+++ b/graphql-server/src/config.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import remoteSchemas from './remoteSchemas';
+import remoteSchemas, {POLKASSEMBLY_URLS} from './remoteSchemas';
 
 dotenv.config({ debug: true });
 
@@ -10,6 +10,7 @@ if (!process.env.ETH_MAINNET_PROVIDER) {
 const config = {
   apiPort: process.env.API_PORT || 5000,
   remoteSchemaConfig: remoteSchemas,
+  polkassemblyUrls: POLKASSEMBLY_URLS,
   ethMainnetProvider: process.env.ETH_MAINNET_PROVIDER as string,
   bscProvider: 'https://bsc-dataseed.binance.org/',
 };

--- a/graphql-server/src/index.ts
+++ b/graphql-server/src/index.ts
@@ -61,6 +61,26 @@ async function makeAggregatedSchema() {
     ],
   });
 
+  const polkassemblyExecutorPolkadot = makeRemoteExecutor(config.polkassemblyUrls.polkadot);
+  const polkassemblySchemaPolkadot = wrapSchema({
+    schema: await introspectSchema(polkassemblyExecutorPolkadot),
+    executor: polkassemblyExecutorPolkadot,
+    transforms: [
+      new RenameTypes((name) => `Polkadot${capitalize(name)}`),
+      new RenameRootFields((_, name) => `Polkadot${capitalize(name)}`),
+    ],
+  })
+
+  const polkassemblyExecutorKusama = makeRemoteExecutor(config.polkassemblyUrls.kusama);
+  const polkassemblySchemaKusama = wrapSchema({
+    schema: await introspectSchema(polkassemblyExecutorKusama),
+    executor: polkassemblyExecutorKusama,
+    transforms: [
+      new RenameTypes((name) => `Kusama${capitalize(name)}`),
+      new RenameRootFields((_, name) => `Kusama${capitalize(name)}`),
+    ],
+  })
+
   return stitchSchemas({
     subschemas: [
       wrappedSubstrateChainSchema,
@@ -68,6 +88,8 @@ async function makeAggregatedSchema() {
       wrappedGalaxySchema,
       wrappedEvmChainSchemaSchema,
       ...remoteSchemas,
+      polkassemblySchemaPolkadot,
+      polkassemblySchemaKusama,
     ],
   });
 }

--- a/graphql-server/src/remoteSchemas.ts
+++ b/graphql-server/src/remoteSchemas.ts
@@ -24,3 +24,8 @@ export default [
     url: 'https://api.thegraph.com/subgraphs/name/litentry/identity-subgraph-bsc',
   },
 ];
+
+export const POLKASSEMBLY_URLS = {
+  polkadot: 'https://polkadot.polkassembly.io/v1/graphql',
+  kusama: 'https://kusama.polkassembly.io/v1/graphql'
+}


### PR DESCRIPTION
Stitched the polkassembly schemas for Polkadot and Kusama into the Litentry graph.

For now this is a prerequisite for migrating polkassembly discussions from rn-app to litentry graph and this also opens the possibility to uniformly consuming polkassembly data through litentry graph.