### PR TITLE
Add fields feeFrozen(to replace freeFrozen) and miscFrozen to account…

### DIFF
--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -30,12 +30,16 @@ export type Account = {
 
 export type AccountBalance = {
   __typename?: 'AccountBalance';
+  feeFrozen: Scalars['String'];
+  formattedFeeFrozen: Scalars['String'];
   formattedFree: Scalars['String'];
   formattedFreeFrozen: Scalars['String'];
+  formattedMiscFrozen: Scalars['String'];
   formattedReserved: Scalars['String'];
   formattedTotal: Scalars['String'];
   free: Scalars['String'];
   freeFrozen: Scalars['String'];
+  miscFrozen: Scalars['String'];
   reserved: Scalars['String'];
   total: Scalars['String'];
 };
@@ -1037,12 +1041,16 @@ export type AccountBalanceResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['AccountBalance'] = ResolversParentTypes['AccountBalance'],
 > = {
+  feeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  formattedFeeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedFree?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedFreeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  formattedMiscFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedReserved?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedTotal?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   free?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   freeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  miscFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   reserved?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   total?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/subschemas/substrate-chain/src/services/accountsService.ts
+++ b/subschemas/substrate-chain/src/services/accountsService.ts
@@ -1,6 +1,9 @@
-import {ApiPromise} from '@polkadot/api';
-import type {Account, RegistrationJudgement} from '../generated/resolvers-types';
-import {formatBalance} from './substrateChainService';
+import { ApiPromise } from '@polkadot/api';
+import type {
+  Account,
+  RegistrationJudgement,
+} from '../generated/resolvers-types';
+import { formatBalance } from './substrateChainService';
 
 export class AccountsService {
   #api: ApiPromise;
@@ -19,38 +22,45 @@ export class AccountsService {
   }
 
   public async getAccounts(addresses: string[]): Promise<Account[]> {
-    return Promise.all(addresses.map((address) => this.getAccountDisplay(address)));
+    return Promise.all(
+      addresses.map((address) => this.getAccountDisplay(address)),
+    );
   }
 
   public async getAccount(address: string): Promise<Account> {
     const accountInfo = await this.#api.derive.accounts.info(address);
-    const {data: accountData} = await this.#api.query.system.account(address);
+    const { data: accountData } = await this.#api.query.system.account(address);
 
     const total = accountData.free.add(accountData.reserved);
     const reserved = accountData.reserved;
     const free = accountData.free;
-    const freeFrozen = accountData.feeFrozen;
+    const feeFrozen = accountData.feeFrozen;
+    const miscFrozen = accountData.miscFrozen;
 
     const display = accountInfo.identity.displayParent
-      ? `${accountInfo.identity.displayParent}/${accountInfo.identity.display || accountInfo.identity.displayParent}`
+      ? `${accountInfo.identity.displayParent}/${
+          accountInfo.identity.display || accountInfo.identity.displayParent
+        }`
       : accountInfo.identity.display;
 
     return {
       address,
       registration: {
         ...accountInfo.identity,
-        judgements: accountInfo.identity.judgements.map<RegistrationJudgement>(([index, judgement]) => ({
-          registrarIndex: index.toNumber(),
-          judgement: {
-            isErroneous: judgement.isErroneous,
-            isFeePaid: judgement.isFeePaid,
-            isKnownGood: judgement.isKnownGood,
-            isLowQuality: judgement.isLowQuality,
-            isOutOfDate: judgement.isOutOfDate,
-            isReasonable: judgement.isReasonable,
-            isUnknown: judgement.isUnknown,
-          },
-        })),
+        judgements: accountInfo.identity.judgements.map<RegistrationJudgement>(
+          ([index, judgement]) => ({
+            registrarIndex: index.toNumber(),
+            judgement: {
+              isErroneous: judgement.isErroneous,
+              isFeePaid: judgement.isFeePaid,
+              isKnownGood: judgement.isKnownGood,
+              isLowQuality: judgement.isLowQuality,
+              isOutOfDate: judgement.isOutOfDate,
+              isReasonable: judgement.isReasonable,
+              isUnknown: judgement.isUnknown,
+            },
+          }),
+        ),
       },
       display: display ?? address.toUpperCase(),
       hasIdentity: Boolean(display),
@@ -61,8 +71,12 @@ export class AccountsService {
         formattedReserved: formatBalance(this.#api, reserved),
         free: free.toString(),
         formattedFree: formatBalance(this.#api, free),
-        freeFrozen: freeFrozen.toString(),
-        formattedFreeFrozen: formatBalance(this.#api, freeFrozen),
+        freeFrozen: feeFrozen.toString(),
+        formattedFreeFrozen: formatBalance(this.#api, feeFrozen),
+        feeFrozen: feeFrozen.toString(),
+        formattedFeeFrozen: formatBalance(this.#api, feeFrozen),
+        miscFrozen: miscFrozen.toString(),
+        formattedMiscFrozen: formatBalance(this.#api, miscFrozen),
       },
     };
   }

--- a/subschemas/substrate-chain/src/typeDefs/account.ts
+++ b/subschemas/substrate-chain/src/typeDefs/account.ts
@@ -36,6 +36,10 @@ export default /* GraphQL */ `
     formattedFree: String!
     freeFrozen: String!
     formattedFreeFrozen: String!
+    feeFrozen: String!
+    formattedFeeFrozen: String!
+    miscFrozen: String!
+    formattedMiscFrozen: String!
   }
 
   type Account {


### PR DESCRIPTION
I've added a couple of new fields:

- `feeFrozen` and `formattedFeeFrozen` to replace `freeFrozen` and `formattedFreeFrozen` when the client updates.

- `miscFrozen` and `formattedMiscFrozen` - This is because I want to align the Balances resolver data to this one:
https://github.com/litentry/litentry-graph/blob/main/subschemas/substrate-chain/src/typeDefs/balance.ts#L2-L7
