### PR TITLE
ON HOLD: Remove account balance free frozen

### DIFF
--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -33,12 +33,10 @@ export type AccountBalance = {
   feeFrozen: Scalars['String'];
   formattedFeeFrozen: Scalars['String'];
   formattedFree: Scalars['String'];
-  formattedFreeFrozen: Scalars['String'];
   formattedMiscFrozen: Scalars['String'];
   formattedReserved: Scalars['String'];
   formattedTotal: Scalars['String'];
   free: Scalars['String'];
-  freeFrozen: Scalars['String'];
   miscFrozen: Scalars['String'];
   reserved: Scalars['String'];
   total: Scalars['String'];
@@ -98,24 +96,10 @@ export type AuctionsSummary = {
 export type Balance = {
   __typename?: 'Balance';
   consumers: Scalars['Int'];
-  data: BalanceData;
+  data: AccountBalance;
   nonce: Scalars['Int'];
   providers: Scalars['Int'];
   sufficients: Scalars['Int'];
-};
-
-export type BalanceData = {
-  __typename?: 'BalanceData';
-  feeFrozen: Scalars['String'];
-  formattedFeeFrozen: Scalars['String'];
-  formattedFree: Scalars['String'];
-  formattedMiscFrozen: Scalars['String'];
-  formattedReserved: Scalars['String'];
-  formattedTotal: Scalars['String'];
-  free: Scalars['String'];
-  miscFrozen: Scalars['String'];
-  reserved: Scalars['String'];
-  total: Scalars['String'];
 };
 
 export type BountiesSummary = {
@@ -778,7 +762,6 @@ export type ResolversTypes = {
   AuctionsInfo: ResolverTypeWrapper<AuctionsInfo>;
   AuctionsSummary: ResolverTypeWrapper<AuctionsSummary>;
   Balance: ResolverTypeWrapper<Balance>;
-  BalanceData: ResolverTypeWrapper<BalanceData>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   BountiesSummary: ResolverTypeWrapper<BountiesSummary>;
   Bounty: ResolverTypeWrapper<
@@ -923,7 +906,6 @@ export type ResolversParentTypes = {
   AuctionsInfo: AuctionsInfo;
   AuctionsSummary: AuctionsSummary;
   Balance: Balance;
-  BalanceData: BalanceData;
   Boolean: Scalars['Boolean'];
   BountiesSummary: BountiesSummary;
   Bounty: Omit<Bounty, 'bountyStatus' | 'proposer'> & {
@@ -1044,12 +1026,10 @@ export type AccountBalanceResolvers<
   feeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedFeeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedFree?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  formattedFreeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedMiscFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedReserved?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedTotal?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   free?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  freeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   miscFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   reserved?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   total?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -1133,27 +1113,10 @@ export type BalanceResolvers<
   ParentType extends ResolversParentTypes['Balance'] = ResolversParentTypes['Balance'],
 > = {
   consumers?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  data?: Resolver<ResolversTypes['BalanceData'], ParentType, ContextType>;
+  data?: Resolver<ResolversTypes['AccountBalance'], ParentType, ContextType>;
   nonce?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   providers?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sufficients?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type BalanceDataResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['BalanceData'] = ResolversParentTypes['BalanceData'],
-> = {
-  feeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  formattedFeeFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  formattedFree?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  formattedMiscFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  formattedReserved?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  formattedTotal?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  free?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  miscFrozen?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  reserved?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  total?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1856,7 +1819,6 @@ export type Resolvers<ContextType = any> = {
   AuctionsInfo?: AuctionsInfoResolvers<ContextType>;
   AuctionsSummary?: AuctionsSummaryResolvers<ContextType>;
   Balance?: BalanceResolvers<ContextType>;
-  BalanceData?: BalanceDataResolvers<ContextType>;
   BountiesSummary?: BountiesSummaryResolvers<ContextType>;
   Bounty?: BountyResolvers<ContextType>;
   BountyStatus?: BountyStatusResolvers<ContextType>;

--- a/subschemas/substrate-chain/src/services/accountsService.ts
+++ b/subschemas/substrate-chain/src/services/accountsService.ts
@@ -71,8 +71,6 @@ export class AccountsService {
         formattedReserved: formatBalance(this.#api, reserved),
         free: free.toString(),
         formattedFree: formatBalance(this.#api, free),
-        freeFrozen: feeFrozen.toString(),
-        formattedFreeFrozen: formatBalance(this.#api, feeFrozen),
         feeFrozen: feeFrozen.toString(),
         formattedFeeFrozen: formatBalance(this.#api, feeFrozen),
         miscFrozen: miscFrozen.toString(),

--- a/subschemas/substrate-chain/src/typeDefs/account.ts
+++ b/subschemas/substrate-chain/src/typeDefs/account.ts
@@ -34,8 +34,6 @@ export default /* GraphQL */ `
     formattedReserved: String!
     free: String!
     formattedFree: String!
-    freeFrozen: String!
-    formattedFreeFrozen: String!
     feeFrozen: String!
     formattedFeeFrozen: String!
     miscFrozen: String!

--- a/subschemas/substrate-chain/src/typeDefs/balance.ts
+++ b/subschemas/substrate-chain/src/typeDefs/balance.ts
@@ -1,22 +1,10 @@
 export default /* GraphQL */ `
-  type BalanceData {
-    total: String!
-    formattedTotal: String!
-    reserved: String!
-    formattedReserved: String!
-    free: String!
-    formattedFree: String!
-    feeFrozen: String!
-    formattedFeeFrozen: String!
-    miscFrozen: String!
-    formattedMiscFrozen: String!
-  }
   type Balance {
     nonce: Int!
     consumers: Int!
     providers: Int!
     sufficients: Int!
-    data: BalanceData!
+    data: AccountBalance!
   }
   type Query {
     balance(address: String!, blockNumber: Int): Balance!


### PR DESCRIPTION
This is the PR that removes the wrongly spelled fields:
- `freeFrozen`
- `formattedFreeFrozen`

**`Important`**: we can only deploy this once the client has updated.

We also remove the need for the `BalanceData` to exist, keeping only `AccountBalance`.