### PR TITLE
Fix council query

### DIFF
--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -212,7 +212,7 @@ export type CouncilMember = {
   address: Scalars['String'];
   backing: Scalars['String'];
   formattedBacking: Scalars['String'];
-  voters: Array<Account>;
+  voters: Array<Scalars['String']>;
 };
 
 export type CouncilMotion = {
@@ -806,12 +806,7 @@ export type ResolversTypes = {
       runnersUp: Array<ResolversTypes['CouncilMember']>;
     }
   >;
-  CouncilMember: ResolverTypeWrapper<
-    Omit<CouncilMember, 'account' | 'voters'> & {
-      account: ResolversTypes['Account'];
-      voters: Array<ResolversTypes['Account']>;
-    }
-  >;
+  CouncilMember: ResolverTypeWrapper<Omit<CouncilMember, 'account'> & { account: ResolversTypes['Account'] }>;
   CouncilMotion: ResolverTypeWrapper<
     Omit<CouncilMotion, 'proposal' | 'votes'> & {
       proposal: ResolversTypes['MotionProposal'];
@@ -947,10 +942,7 @@ export type ResolversParentTypes = {
     primeMember?: Maybe<ResolversParentTypes['CouncilMember']>;
     runnersUp: Array<ResolversParentTypes['CouncilMember']>;
   };
-  CouncilMember: Omit<CouncilMember, 'account' | 'voters'> & {
-    account: ResolversParentTypes['Account'];
-    voters: Array<ResolversParentTypes['Account']>;
-  };
+  CouncilMember: Omit<CouncilMember, 'account'> & { account: ResolversParentTypes['Account'] };
   CouncilMotion: Omit<CouncilMotion, 'proposal' | 'votes'> & {
     proposal: ResolversParentTypes['MotionProposal'];
     votes?: Maybe<ResolversParentTypes['ProposalVotes']>;
@@ -1276,7 +1268,7 @@ export type CouncilMemberResolvers<
   address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   backing?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   formattedBacking?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  voters?: Resolver<Array<ResolversTypes['Account']>, ParentType, ContextType>;
+  voters?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/subschemas/substrate-chain/src/resolvers/Query/council.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/council.ts
@@ -44,7 +44,7 @@ export async function council(
         account,
         backing: balance.toString(),
         formattedBacking: formatBalance(api, balance),
-        voters: await accountsService.getAccounts(votesByCandidates[String(accountId)] || []),
+        voters: votesByCandidates[String(accountId)] || [],
       };
     }),
   );
@@ -60,7 +60,7 @@ export async function council(
         account,
         backing: balance.toString(),
         formattedBacking: formatBalance(api, balance),
-        voters: await accountsService.getAccounts(votesByCandidates[String(accountId)] || []),
+        voters: votesByCandidates[String(accountId)] || [],
       };
     }),
   );

--- a/subschemas/substrate-chain/src/typeDefs/council.ts
+++ b/subschemas/substrate-chain/src/typeDefs/council.ts
@@ -4,7 +4,7 @@ export default /* GraphQL */ `
     account: Account!
     backing: String!
     formattedBacking: String!
-    voters: [Account!]!
+    voters: [String!]!
   }
 
   type TermProgress {


### PR DESCRIPTION
Since in case of a council member voters list being too long when we try to resolve the voters account data in the same query the kusama chain gets overloaded with requests and thus blocked with an error response.

For more details please check https://litentry.slack.com/archives/C02C0QH27CY/p1653639994699229

To fix this issue now the voters list is resolved only as a list of address strings and the clients can fetch the voters account details lazily if needed.