### PR TITLE
Adding unformatted raised value in Auction

### DIFF
--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -55,6 +55,7 @@ export type AccountInfo = {
 export type Auction = {
   __typename?: 'Auction';
   endingPeriod?: Maybe<AuctionEndingPeriod>;
+  formattedRaised: Scalars['String'];
   leasePeriod?: Maybe<AuctionLeasePeriod>;
   raised: Scalars['String'];
   raisedPercent: Scalars['Float'];
@@ -1066,6 +1067,7 @@ export type AuctionResolvers<
   ParentType extends ResolversParentTypes['Auction'] = ResolversParentTypes['Auction'],
 > = {
   endingPeriod?: Resolver<Maybe<ResolversTypes['AuctionEndingPeriod']>, ParentType, ContextType>;
+  formattedRaised?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   leasePeriod?: Resolver<Maybe<ResolversTypes['AuctionLeasePeriod']>, ParentType, ContextType>;
   raised?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   raisedPercent?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;

--- a/subschemas/substrate-chain/src/resolvers/Query/auctions.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/auctions.ts
@@ -77,7 +77,8 @@ const getLatestAuction = (
       remaining: getBlockTime(api, endingIn.sub(currentPosition)).timeStringParts,
       remainingPercent,
     },
-    raised: formatBalance(api, raised),
+    raised: raised.toString(),
+    formattedRaised: formatBalance(api, raised),
     raisedPercent,
     winningBid: latestWinningBid
       ? {

--- a/subschemas/substrate-chain/src/typeDefs/auctions.ts
+++ b/subschemas/substrate-chain/src/typeDefs/auctions.ts
@@ -34,6 +34,7 @@ export default /* GraphQL */ `
     leasePeriod: AuctionLeasePeriod
     endingPeriod: AuctionEndingPeriod
     raised: String!
+    formattedRaised: String!
     raisedPercent: Float!
     winningBid: AuctionBid
   }


### PR DESCRIPTION
Because of space constraint in the app sometimes it is needed to apply specific formatting to a value, such as formatting into a shorter string.

For that we need to return the unformatted value in addition with a basic formatted one form the graph.