### PR TITLE
Add Litentry rococo test net in Litentry graph

### DIFF
--- a/graphql-server/src/substrateApi.ts
+++ b/graphql-server/src/substrateApi.ts
@@ -1,12 +1,13 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
 
-export type SubstrateNetwork = 'kusama' | 'polkadot' | 'litmus' | 'khala';
+export type SubstrateNetwork = 'kusama' | 'polkadot' | 'litmus' | 'litentry-rococo' | 'khala';
 
 // TODO: get ws providers from .env
 const polkadotWsProvider = new WsProvider('wss://rpc.polkadot.io');
 const kusamaWsProvider = new WsProvider('wss://kusama.api.onfinality.io/public-ws');
 const khalaWsProvider = new WsProvider('wss://khala.api.onfinality.io/public-ws');
 const litmusWsProvider = new WsProvider('wss://rpc.litmus-parachain.litentry.io');
+const litentryRococoProvider = new WsProvider('wss://rpc.rococo-parachain-sg.litentry.io')
 
 const ONE_HOUR_INTERVAL = 60 * 60 * 1000;
 let apiInstanceCount = 1;
@@ -25,6 +26,9 @@ async function createApis() {
   const litmusApi = await ApiPromise.create({ provider: litmusWsProvider });
   await litmusApi.isReady;
 
+  const litentryRococoApi = await ApiPromise.create({provider: litentryRococoProvider});
+  await litentryRococoApi.isReady;
+
   return (network?: SubstrateNetwork) => {
     switch (network) {
       case 'kusama':
@@ -33,6 +37,8 @@ async function createApis() {
         return litmusApi;
       case 'khala':
         return khalaApi;
+      case 'litentry-rococo':
+        return litentryRococoApi;
 
       default:
         return polkadotApi;

--- a/subschemas/substrate-chain/src/generated/resolvers-types.ts
+++ b/subschemas/substrate-chain/src/generated/resolvers-types.ts
@@ -185,7 +185,7 @@ export type Council = {
   members: Array<CouncilMember>;
   primeMember?: Maybe<CouncilMember>;
   runnersUp: Array<CouncilMember>;
-  termProgress: TermProgress;
+  termProgress?: Maybe<TermProgress>;
   totalCandidates: Scalars['Int'];
   totalMembers: Scalars['Int'];
   totalRunnersUp: Scalars['Int'];
@@ -1218,7 +1218,7 @@ export type CouncilResolvers<
   members?: Resolver<Array<ResolversTypes['CouncilMember']>, ParentType, ContextType>;
   primeMember?: Resolver<Maybe<ResolversTypes['CouncilMember']>, ParentType, ContextType>;
   runnersUp?: Resolver<Array<ResolversTypes['CouncilMember']>, ParentType, ContextType>;
-  termProgress?: Resolver<ResolversTypes['TermProgress'], ParentType, ContextType>;
+  termProgress?: Resolver<Maybe<ResolversTypes['TermProgress']>, ParentType, ContextType>;
   totalCandidates?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   totalMembers?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   totalRunnersUp?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/subschemas/substrate-chain/src/resolvers/Query/council.ts
+++ b/subschemas/substrate-chain/src/resolvers/Query/council.ts
@@ -96,20 +96,23 @@ export async function council(
     }
   }
 
-  const { termLeft, percentage } = getTermLeft(bnToBn(electionsInfo.termDuration || 0), bestNumber);
-  const { formattedTime: formattedTermLeft, timeStringParts: termLeftParts } = getBlockTime(api, termLeft);
-  const { formattedTime: formattedTermDuration, timeStringParts: termDurationParts } = getBlockTime(
-    api,
-    electionsInfo.termDuration,
-  );
-
-  const termProgress: TermProgress = {
-    termDuration: formattedTermDuration,
-    termDurationParts: termDurationParts,
-    termLeft: formattedTermLeft,
-    termLeftParts,
-    percentage,
-  };
+  let termProgress: TermProgress | null = null
+  if(electionsInfo.termDuration) {
+    const { termLeft, percentage } = getTermLeft(bnToBn(electionsInfo.termDuration || 0), bestNumber);
+    const { formattedTime: formattedTermLeft, timeStringParts: termLeftParts } = getBlockTime(api, termLeft);
+    const { formattedTime: formattedTermDuration, timeStringParts: termDurationParts } = getBlockTime(
+      api,
+      electionsInfo.termDuration,
+    );
+  
+    termProgress = {
+      termDuration: formattedTermDuration,
+      termDurationParts: termDurationParts,
+      termLeft: formattedTermLeft,
+      termLeftParts,
+      percentage,
+    };
+  }
 
   return {
     members,

--- a/subschemas/substrate-chain/src/typeDefs/council.ts
+++ b/subschemas/substrate-chain/src/typeDefs/council.ts
@@ -25,7 +25,7 @@ export default /* GraphQL */ `
     totalMembers: Int!
     desiredRunnersUp: Int!
     totalRunnersUp: Int!
-    termProgress: TermProgress!
+    termProgress: TermProgress
   }
 
   type ProposalVotes {


### PR DESCRIPTION
### Description:

- Added litentry-rococo instance in the graph
- Since council election term duration is missing in the test net council resolver was needed to be fixed.